### PR TITLE
Add missing device-width meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Der AfKollektor.</title>
   <link href="./index.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
Fix issue #12 .
Forces browser to render page on device-width.